### PR TITLE
Allow add_simultaneous and ..._options

### DIFF
--- a/lib/JSON/Karabiner/Manipulator/Actions/From.pm
+++ b/lib/JSON/Karabiner/Manipulator/Actions/From.pm
@@ -35,7 +35,7 @@ sub add_key_code {
     croak 'Only one input type can be entered for "from" defintions';
   }
   my ($letter_code, $ms);
-  if ($key_codes[0] =~ /-([A-Z])|(\d+)$/) {
+  if ($key_codes[0] =~ /-([A-Z])|(\d\{2,\})$/) {
     $letter_code = $1;
     $ms = $2;
   }

--- a/lib/JSON/Karabiner/Manipulator/Actions/From.pm
+++ b/lib/JSON/Karabiner/Manipulator/Actions/From.pm
@@ -95,16 +95,20 @@ sub add_simultaneous_options {
   my @values = @_;
   my @allowed_options = qw ( detect_key_down_uninterruptedly
                              key_down_order key_up_when to_after_key_up );
-  my $exists = grep { $_ = $option } @allowed_options;
-  croak "Simultaneous option is not a valid option" if $exists;
+  my $exists = grep { $_ eq $option } @allowed_options;
+  croak "Simultaneous option $option is not a valid option" unless ($exists == 1);
   my $value = $values[0];
 
   #TODO: detect if option already exists and die if it does
   #TODO: offer suggestions if error thrown
-  croak "Simultaneous option $option has already been set" if ($s->{"so_${option}_is_set"} == 1);
+  croak "Simultaneous option $option has already been set" if $s->{"so_${option}_is_set"};
 
   if ($option eq 'detect_key_down_uninterruptedly') {
-    if ($value !~ /true|false/) {
+    if ($value =~ /true/) {
+      $value = $JSON::true;
+    } elsif ($value =~ /false/) {
+      $value = $JSON::false;
+    } else {
       croak "$value is not a valid option for $option";
     }
   } elsif ($option eq 'key_down_order' || $option eq 'key_up_order') {
@@ -120,8 +124,13 @@ sub add_simultaneous_options {
     croak 'This option is currently unspported by JSON::Karabiner';
   }
 
-  $s->{"so_${option}_is_set"} = 1;
+  if (defined $s->{data}{simultaneous_options}) {
+    %{$s->{data}{simultaneous_options}} = (%{$s->{data}{simultaneous_options}}, $option => $value);
+  } else {
+    $s->{data}{simultaneous_options} = { $option => $value };
+  }
 
+  $s->{"so_${option}_is_set"} = 1;
 }
 
 # ABSTRACT: From object definition


### PR DESCRIPTION
I was unable to use JSON::Karabiner to produce rules for simultaneous keypresses. The below changes work for me. The PR is mostly to help me figure out the GitHub interface ... I figure you'll quickly see better ways of achieving the same things, but maybe this will help spark a few ideas.

Cheers!

### Example file
```
use JSON::Karabiner::Manipulator;
set_title 'boolean test';
set_rule_name 'a->b is c';
new_manipulator;
add_action 'from';
add_simultaneous 'a', 'b';
add_simultaneous_options 'detect_key_down_uninterruptedly', 'false';
add_action 'to';
add_key_code 'c';
write_file;
```

### Expected results
Compiled by JSON::Karabiner, loads in Karabiner-Elements, changes a key combo of 'a' and 'b' to 'c'.

This is an example of the desired output:
```
{
   "rules" : [
      {
         "description" : "a->b is c",
         "manipulators" : [
            {
               "from" : {
                  "simultaneous" : [
                     {
                        "key_code" : "a"
                     },
                     {
                        "key_code" : "b"
                     }
                  ],
                  "simultaneous_options" : {
                     "detect_key_down_uninterruptedly" : false,
                     "key_down_order" : "strict"
                  }
               },
               "to" : [
                  {
                     "key_code" : "c"
                  }
               ],
               "type" : "basic"
            }
         ]
      }
   ],
   "title" : "boolean test"
}
```

### Observed results
JSON::Karabiner fails to compile the example file with the following message:
```
Simultaneous option is not a valid option at /usr/local/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0/JSON/Karabiner/Manipulator.pm line 116.
```

### Proposed fixes
In JSON/Karabiner/Manipulator/Actions/From.pm --
In sub add_simultaneous_options --

#### 1: initialization of $exists
Fix typo where what should be a test is an assignment: `$_ eq $option` not `$_ = $option`.

#### 2: standardize error message
The other $option croak messages specify what the offending $option value was, so it is included here as well.

This is unrelated to the main issue; I could split it into two PRs if that helps.

#### 3: testing $exists
Since the above assignment changed each element of @allowed_options to $option before assigning a value to $exists, the current test (`croak...if $exists`) will always be true. Instead, we want $option to match exactly one element of @allowed_options, so the test is changed to `croak...unless ($exists == 1)`.
#### 4: allow uninitialized $option
The `croak...if ($s->{"so${option}_is_set"} == 1)` will always test against an uninitialized value on the first iteration. The predominant idiom for similar tests in this software is to simply test its existence, so that pattern is maintained with `croak...if $s->{"so_${option}_is_set"}`.

#### 5: use JSON booleans
As is, the package will export true and false values as strings, which are rejected by Karabiner-Elements (`"error: ... must be boolean, but is "true"`). Therefore, while testing the validity of the proposed detect_key_down_uninterruptedly value, it is also assigned to `$JSON::true` or `$JSON::false`.

I suspect there is a reusable way to do this but I have not looked.

#### 6: implement settings
As is, the package only records whether these settings have been applied or not; they never actually change the JSON output. So `$s->{data}{simultaneous_options}` is given a value.

The construction of the if-defined block is ugly, but yields a single JSON object that both looks good in JSON and is accepted by Karabiner-Elements. Concatenating the hashes did not work for me (Karabiner-Elements: "error: json must be object, but is [{a:b},{c:d}]"). Another approach that appears to work is to output multiple simultaneous_options objects in the JSON file, but this does not appear convenient with JSON::Karabiner's internal data structure.